### PR TITLE
Fix: Frontend Routing

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -34,6 +34,7 @@ if (config('filament-fabricator.routing.enabled')) {
                     ['component' => $component, 'page' => $filamentFabricatorPage]
                 );
             })
-            ->where('filamentFabricatorPage', '.*');
+            ->where('filamentFabricatorPage', '.*')
+            ->fallback();
         });
 }

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -12,7 +12,7 @@ class Page extends Model implements Contract
 {
     public function __construct(array $attributes = [])
     {
-        if (! isset($this->table)) {
+        if (blank($this->table)) {
             $this->setTable(config('filament-fabricator.table_name', 'pages'));
         }
 

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -135,8 +135,8 @@ class PageResource extends Resource
                 TextColumn::make('url')
                     ->label(__('filament-fabricator::page-resource.labels.url'))
                     ->toggleable()
-                    ->getStateUsing(fn (?PageContract $record) => FilamentFabricator::getPageUrls()[$record->id] ?? null)
-                    ->url(fn (?PageContract $record) => FilamentFabricator::getPageUrls()[$record->id] ?? null)
+                    ->getStateUsing(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?? null)
+                    ->url(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?? null, true)
                     ->visible(config('filament-fabricator.routing.enabled')),
 
                 BadgeColumn::make('layout')
@@ -161,7 +161,7 @@ class PageResource extends Resource
                 EditAction::make(),
                 Action::make('visit')
                     ->label(__('filament-fabricator::page-resource.actions.visit'))
-                    ->url(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true))
+                    ->url(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?? null)
                     ->icon('heroicon-o-external-link')
                     ->openUrlInNewTab()
                     ->color('success')

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -135,8 +135,8 @@ class PageResource extends Resource
                 TextColumn::make('url')
                     ->label(__('filament-fabricator::page-resource.labels.url'))
                     ->toggleable()
-                    ->getStateUsing(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?? null)
-                    ->url(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?? null, true)
+                    ->getStateUsing(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?: null)
+                    ->url(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?: null, true)
                     ->visible(config('filament-fabricator.routing.enabled')),
 
                 BadgeColumn::make('layout')
@@ -161,7 +161,7 @@ class PageResource extends Resource
                 EditAction::make(),
                 Action::make('visit')
                     ->label(__('filament-fabricator::page-resource.actions.visit'))
-                    ->url(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?? null)
+                    ->url(fn (?PageContract $record) => config('filament-fabricator.routing.prefix') . FilamentFabricator::getPageUrlFromId($record->id, true) ?: null)
                     ->icon('heroicon-o-external-link')
                     ->openUrlInNewTab()
                     ->color('success')


### PR DESCRIPTION
Marks fabricator route as a fallback route, so that it won't override application routes

fixes https://github.com/Z3d0X/filament-fabricator/issues/33 & https://github.com/Z3d0X/filament-fabricator/issues/25

