### PR TITLE
Fix custom PageResource not being considered on Pages

### DIFF
--- a/src/Resources/PageResource/Pages/CreatePage.php
+++ b/src/Resources/PageResource/Pages/CreatePage.php
@@ -8,4 +8,9 @@ use Z3d0X\FilamentFabricator\Resources\PageResource;
 class CreatePage extends CreateRecord
 {
     protected static string $resource = PageResource::class;
+
+    public static function getResource(): string
+    {
+        return config('filament-fabricator.page-resource') ?? static::$resource;
+    }
 }

--- a/src/Resources/PageResource/Pages/EditPage.php
+++ b/src/Resources/PageResource/Pages/EditPage.php
@@ -12,6 +12,11 @@ class EditPage extends EditRecord
 {
     protected static string $resource = PageResource::class;
 
+    public static function getResource(): string
+    {
+        return config('filament-fabricator.page-resource') ?? static::$resource;
+    }
+
     protected function getActions(): array
     {
         return [

--- a/src/Resources/PageResource/Pages/ListPages.php
+++ b/src/Resources/PageResource/Pages/ListPages.php
@@ -10,6 +10,11 @@ class ListPages extends ListRecords
 {
     protected static string $resource = PageResource::class;
 
+    public static function getResource(): string
+    {
+        return config('filament-fabricator.page-resource') ?? static::$resource;
+    }
+
     protected function getActions(): array
     {
         return [

--- a/src/Resources/PageResource/Pages/ViewPage.php
+++ b/src/Resources/PageResource/Pages/ViewPage.php
@@ -12,6 +12,11 @@ class ViewPage extends ViewRecord
 {
     protected static string $resource = PageResource::class;
 
+    public static function getResource(): string
+    {
+        return config('filament-fabricator.page-resource') ?? static::$resource;
+    }
+
     protected function getActions(): array
     {
         return [


### PR DESCRIPTION
Currently, if you define a custom Resource on `filament-fabricator.php`, this resource is not considered on the plugin `Create`, `Edit`, `List`, and `View` pages.

```php
'page-resource' => \App\Models\PageResource::class,
```

This PR fixes this matter, adding the method below on every page:

```php
public static function getResource(): string
{
    return config('filament-fabricator.page-resource') ?? static::$resource;
}
```

