### PR TITLE
[Docs]: Remove Peek from installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 You can install the package via composer:
 
 ```bash
-composer require pboivin/filament-peek:"^2.0.0-beta4" z3d0x/filament-fabricator
+composer require z3d0x/filament-fabricator
 ```
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@
 
 Once you have [Filament Panels](https://filamentphp.com/docs/3.x/panels/installation) configured. You can install this package via composer:
 ```bash
-composer require pboivin/filament-peek:"^2.0.0-beta4" z3d0x/filament-fabricator
+composer require z3d0x/filament-fabricator
 ```
 
 After that run the install command: (this will publish the config & migrations)


### PR DESCRIPTION
As per Patrick's comment https://github.com/Z3d0X/filament-fabricator/issues/86#issuecomment-1701329401 Peek now has a 2.0 stable version so it will not be needed to be installed separately. 

I just updated the readme file to reflect this. 

Cheers!
V