### PR TITLE
Respect app locale for slug generation

### DIFF
--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -71,7 +71,7 @@ class PageResource extends Resource
                                     ->label(__('filament-fabricator::page-resource.labels.title'))
                                     ->afterStateUpdated(function (Get $get, Set $set, ?string $state, ?PageContract $record) {
                                         if (! $get('is_slug_changed_manually') && filled($state) && blank($record)) {
-                                            $set('slug', Str::slug($state));
+                                            $set('slug', Str::slug($state, language: config('app.locale', 'en')));
                                         }
                                     })
                                     ->debounce('500ms')


### PR DESCRIPTION
Respect the app locale when generating the slug. This is important for the correct slugs in other languages.