### PR TITLE
Allow easier subclassing of the Page model

### DIFF
--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -40,17 +40,17 @@ class Page extends Model implements Contract
 
     public function parent(): BelongsTo
     {
-        return $this->belongsTo(Page::class, 'parent_id');
+        return $this->belongsTo(static::class, 'parent_id');
     }
 
     public function children(): HasMany
     {
-        return $this->hasMany(Page::class, 'parent_id');
+        return $this->hasMany(static::class, 'parent_id');
     }
 
     public function allChildren(): HasMany
     {
-        return $this->hasMany(Page::class, 'parent_id')
+        return $this->hasMany(static::class, 'parent_id')
             ->select('id', 'slug', 'title', 'parent_id')
             ->with('allChildren:id,slug,title,parent_id');
     }


### PR DESCRIPTION
Most of the time, when we use this package and need to have additional functionalities in our Page model, we extend the base Page model.

Currently, due to how the relationships were defined, we'd need to override them with extremely similar code.

The proposed change just removes that need altogether by using the leaf class directly, relying on PHP's `static` class name.