### PR TITLE
Fix for Duplicate Entry SQL Error on 'pages' Table

### DIFF
--- a/database/migrations/create_pages_table.php.stub
+++ b/database/migrations/create_pages_table.php.stub
@@ -11,10 +11,11 @@ return new class extends Migration
         Schema::create(config('filament-fabricator.table_name', 'pages'), function (Blueprint $table) {
             $table->id();
             $table->string('title')->index();
-            $table->string('slug')->unique();
+            $table->string('slug');
             $table->string('layout')->default('default')->index();
             $table->json('blocks');
             $table->foreignId('parent_id')->nullable()->constrained('pages')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->unique(['slug', 'parent_id']);
             $table->timestamps();
         });
     }


### PR DESCRIPTION
This PR addresses a `SQLSTATE[23000] integrity constraint violation` error encountered when inserting a new page with a non-unique slug into the pages table. The error was caused by the `pages_slug_unique` constraint on the slug column.

**Problem**:
The application threw an exception for a duplicate entry for the key `pages.pages_slug_unique` when attempting to insert a new page with the same slug as an existing page, but with a different parent.

**Solution**:
The unique index on the slug column has been removed, and a new compound unique index has been introduced on the combination of `slug` and `parent_id` columns. This allows the same slug to be used as long as it has a different parent, thus ensuring unique URLs for different page hierarchies while avoiding the integrity constraint violation.