### PR TITLE
Fixed incorrect table name during migration

### DIFF
--- a/database/migrations/create_pages_table.php.stub
+++ b/database/migrations/create_pages_table.php.stub
@@ -14,7 +14,7 @@ return new class extends Migration
             $table->string('slug')->unique();
             $table->string('layout')->default('default')->index();
             $table->json('blocks');
-            $table->foreignId('parent_id')->nullable()->constrained('pages')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('parent_id')->nullable()->constrained(config('filament-fabricator.table_name', 'pages'))->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();
         });
     }


### PR DESCRIPTION
Previously, when the fabricator table name was non-default, incorrect table name was used during creation self-reference in migrations. In consequence, migration has failed.

I've made a little patch to solve this problem.

Issue: https://github.com/Z3d0X/filament-fabricator/issues/150