### PR TITLE
Allow string IDs

### DIFF
--- a/src/FilamentFabricatorManager.php
+++ b/src/FilamentFabricatorManager.php
@@ -189,7 +189,7 @@ class FilamentFabricatorManager
         });
     }
 
-    public function getPageUrlFromId(int $id, bool $prefixSlash = false): ?string
+    public function getPageUrlFromId(int|string $id, bool $prefixSlash = false): ?string
     {
         $url = $this->getPageUrls()[$id];
 

--- a/src/Models/Contracts/Page.php
+++ b/src/Models/Contracts/Page.php
@@ -6,12 +6,12 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
- * @property-read int $id
+ * @property-read int|string $id
  * @property-read string $title
  * @property-read string $slug
  * @property-read string $layout
  * @property-read array $blocks
- * @property-read int $parent_id
+ * @property-read int|string $parent_id
  * @property-read \Illuminate\Database\Eloquent\Collection|\Z3d0X\FilamentFabricator\Models\Contracts\Page[] $children
  * @property-read \Illuminate\Database\Eloquent\Collection|\Z3d0X\FilamentFabricator\Models\Contracts\Page[] $allChildren
  * @property-read \Illuminate\Support\Carbon $created_at


### PR DESCRIPTION
I'm currently integrating this package into an existing project that already has a pages table with UUIDs. While working on migrating the data I ran into a `TypeError` when opening the edit page because the UUID is passed as a `string`, but it expects an `integer`.

Due to already existing relations on the UUIDs I'd prefer to keep them as they are.

These changes allow the `id` and `parent_id` fields to be a string.