### PR TITLE
Add exception for runningInConsole in FilamentFabricatorServiceProvid…

### DIFF
--- a/src/FilamentFabricatorServiceProvider.php
+++ b/src/FilamentFabricatorServiceProvider.php
@@ -71,33 +71,35 @@ class FilamentFabricatorServiceProvider extends PackageServiceProvider
 
     public function bootingPackage(): void
     {
-        Route::bind('filamentFabricatorPage', function ($value) {
-            $pageModel = FilamentFabricator::getPageModel();
-
-            $pageUrls = FilamentFabricator::getPageUrls();
-
-            $value = Str::start($value, '/');
-
-            $pageId = array_search($value, $pageUrls);
-
-            return $pageModel::query()
-                ->where('id', $pageId)
-                ->firstOrFail();
-        });
-
-        $this->registerComponentsFromDirectory(
-            Layout::class,
-            config('filament-fabricator.layouts.register'),
-            config('filament-fabricator.layouts.path'),
-            config('filament-fabricator.layouts.namespace')
-        );
-
-        $this->registerComponentsFromDirectory(
-            PageBlock::class,
-            config('filament-fabricator.page-blocks.register'),
-            config('filament-fabricator.page-blocks.path'),
-            config('filament-fabricator.page-blocks.namespace')
-        );
+        if (! $this->app->runningInConsole()) {
+            Route::bind('filamentFabricatorPage', function ($value) {
+                $pageModel = FilamentFabricator::getPageModel();
+    
+                $pageUrls = FilamentFabricator::getPageUrls();
+    
+                $value = Str::start($value, '/');
+    
+                $pageId = array_search($value, $pageUrls);
+    
+                return $pageModel::query()
+                    ->where('id', $pageId)
+                    ->firstOrFail();
+            });
+    
+            $this->registerComponentsFromDirectory(
+                Layout::class,
+                config('filament-fabricator.layouts.register'),
+                config('filament-fabricator.layouts.path'),
+                config('filament-fabricator.layouts.namespace')
+            );
+    
+            $this->registerComponentsFromDirectory(
+                PageBlock::class,
+                config('filament-fabricator.page-blocks.register'),
+                config('filament-fabricator.page-blocks.path'),
+                config('filament-fabricator.page-blocks.namespace')
+            );
+        }
     }
 
     protected function registerComponentsFromDirectory(string $baseClass, array $register, ?string $directory, ?string $namespace): void


### PR DESCRIPTION
Hello,

I've encountered an issue with this package, related to using models directly within Block files. The problem arises when these models are loaded from a ServiceProvider. This becomes evident during a fresh migration process, where the error "table not exists" is thrown because the system attempts to access the table while it is being migrated.

To address this issue, I've made modifications to the `FilamentFabricatorServiceProvider`. My approach involves wrapping certain parts of the service provider logic within an `if` statement that checks if the application is running in console mode. This ensures that the code within the block doesn't execute when commands are running, thereby preventing the Block files from being called prematurely.

Here's the change I've implemented:

```diff
- Route::bind('filamentFabricatorPage', function ($value) {
-     $pageModel = FilamentFabricator::getPageModel();
-     $pageUrls = FilamentFabricator::getPageUrls();
-     $value = Str::start($value, '/');
-     $pageId = array_search($value, $pageUrls);
-     return $pageModel::query()
-         ->where('id', $pageId)
-         ->firstOrFail();
- });
- $this->registerComponentsFromDirectory(
-     Layout::class,
-     config('filament-fabricator.layouts.register'),
-     config('filament-fabricator.layouts.path'),
-     config('filament-fabricator.layouts.namespace')
- );
- $this->registerComponentsFromDirectory(
-     PageBlock::class,
-     config('filament-fabricator.page-blocks.register'),
-     config('filament-fabricator.page-blocks.path'),
-     config('filament-fabricator.page-blocks.namespace')
- );

+ if (! $this->app->runningInConsole()) {
+     Route::bind('filamentFabricatorPage', function ($value) {
+         $pageModel = FilamentFabricator::getPageModel();
+         $pageUrls = FilamentFabricator::getPageUrls();
+         $value = Str::start($value, '/');
+         $pageId = array_search($value, $pageUrls);
+         return $pageModel::query()
+             ->where('id', $pageId)
+             ->firstOrFail();
+     });
+     $this->registerComponentsFromDirectory(
+         Layout::class,
+         config('filament-fabricator.layouts.register'),
+         config('filament-fabricator.layouts.path'),
+         config('filament-fabricator.layouts.namespace')
+     );
+     $this->registerComponentsFromDirectory(
+         PageBlock::class,
+         config('filament-fabricator.page-blocks.register'),
+         config('filament-fabricator.page-blocks.path'),
+         config('filament-fabricator.page-blocks.namespace')
+     );
+ }
```

With this adjustment, the service provider skips this code when Laravel commands are executed, effectively resolving the migration error without impacting the operational functionality of the package.

I hope this fix can be helpful for others facing the same issue and I believe it could be a valuable addition to the package.

Best regards,
Yolan Mees