### PR TITLE
Add a hook to allow mass-preload/batch-load of related data when rendering a page's blocks

### DIFF
--- a/resources/views/components/page-blocks.blade.php
+++ b/resources/views/components/page-blocks.blade.php
@@ -1,14 +1,27 @@
+@aware(['page'])
 @props(['blocks' => []])
+
+@php
+    $groups = \Z3d0X\FilamentFabricator\Helpers::arrayRefsGroupBy($blocks, 'type');
+
+    foreach ($groups as $blockType => &$group) {
+        /**
+         * @var class-string<\Z3d0X\FilamentFabricator\PageBlocks\PageBlock> $blockClass
+         */
+        $blockClass = FilamentFabricator::getPageBlockFromName($blockType);
+
+        if (!empty($blockClass)) {
+            $blockClass::preloadRelatedData($page, $group);
+        }
+    }
+@endphp
 
 @foreach ($blocks as $blockData)
     @php
-        $pageBlock = \Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getPageBlockFromName($blockData['type'])
+        $pageBlock = \Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getPageBlockFromName($blockData['type']);
     @endphp
 
     @isset($pageBlock)
-        <x-dynamic-component
-            :component="$pageBlock::getComponent()"
-            :attributes="new \Illuminate\View\ComponentAttributeBag($pageBlock::mutateData($blockData['data']))"
-        />
+        <x-dynamic-component :component="$pageBlock::getComponent()" :attributes="new \Illuminate\View\ComponentAttributeBag($pageBlock::mutateData($blockData['data']))" />
     @endisset
 @endforeach

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Z3d0X\FilamentFabricator;
+
+abstract class Helpers
+{
+    /**
+     * Group an array of associative arrays by a given key
+     *
+     * @param  array[]  $arr
+     * @return array[]
+     */
+    public static function arrayRefsGroupBy(array &$arr, string $key): array
+    {
+        $ret = [];
+
+        foreach ($arr as &$item) {
+            $ret[$item[$key]][] = &$item;
+        }
+
+        return $ret;
+    }
+}

--- a/src/PageBlocks/PageBlock.php
+++ b/src/PageBlocks/PageBlock.php
@@ -3,6 +3,7 @@
 namespace Z3d0X\FilamentFabricator\PageBlocks;
 
 use Filament\Forms\Components\Builder\Block;
+use Z3d0X\FilamentFabricator\Models\Contracts\Page;
 
 abstract class PageBlock
 {
@@ -28,4 +29,15 @@ abstract class PageBlock
     {
         return $data;
     }
+
+    /**
+     * Hook used to mass-preload related data to reduce the number of DB queries.
+     * For instance, to load model objects/data from their IDs
+     *
+     * @param  (array{
+     *     type: string,
+     *     data: array,
+     * })[]  $blocks  - The array of blocks' data for the given page and the given block type
+     */
+    public static function preloadRelatedData(Page $page, array &$blocks): void {}
 }


### PR DESCRIPTION
Some components, like media-based components, accept either an ID or a `Model` instance as their input. In the latter case, they simply use the instance as is. In the former, they need to load the model from the database using the ID.

As such, using said components with Fabricator (or any kind of builder / repeater) gives us an N+1 query problem. To fix this we could batch the data loading. That is the feature this PR provides.

`Block::preloadRelatedData(Page $page, array &$blocks)` is a public static method that is called once per block type when rendering a page. It's meant to be used for batch loading data or any kind of action that is meant to be done once per page per block type.

For instance, let's say we have a `TextImageBlock` class that extends from `PageBlock` and contains an `image` field (e.g. file picker, curator, media-library). Said field only stores the ID of the media model in the database, and the display component accepts either an ID or a `Model` instance.

In this scenario, we can implement the block's `preloadRelatedData` to batch-load the media models:

```php
class TextImageBlock extends PageBlock {
  // [...]

  #[\Override]
  public static function preloadRelatedData(Page $page, array &$blocks): void {
    parent::preloadRelatedData($page, $blocks);

    $ids = collect($blocks)
      ->lazy()
      ->map(fn ($block) => $block['data']['image'])
      ->flatten()
      ->filter()
      ->unique()
      ->toArray();

    $images = Media::query()
      ->whereIn('id', $ids)
      ->get();

    $images = collect($images)->groupBy('id');

    foreach ($blocks as &$block) {
      $block['data']['image'] = data_get($images, (string) $block['data']['image'])->first();
    }
  }

  // [...]
}
```

This way we only have 1 database query for the medias for the whole page.