### PR TITLE
Defere loading to ensure translations work

### DIFF
--- a/src/FilamentFabricatorServiceProvider.php
+++ b/src/FilamentFabricatorServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Z3d0X\FilamentFabricator;
 
+use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
@@ -14,7 +15,7 @@ use Z3d0X\FilamentFabricator\Facades\FilamentFabricator;
 use Z3d0X\FilamentFabricator\Layouts\Layout;
 use Z3d0X\FilamentFabricator\PageBlocks\PageBlock;
 
-class FilamentFabricatorServiceProvider extends PackageServiceProvider
+class FilamentFabricatorServiceProvider extends PackageServiceProvider implements DeferrableProvider
 {
     public function configurePackage(Package $package): void
     {
@@ -58,6 +59,11 @@ class FilamentFabricatorServiceProvider extends PackageServiceProvider
         }
 
         return array_merge($commands, $aliases);
+    }
+
+    public function provides(): array
+    {
+        return [FilamentFabricatorManager::ID];
     }
 
     public function packageRegistered(): void


### PR DESCRIPTION
I think I discovered a bit of a funny bug: The translation of components in blocks is actually only working because of the package name starting with "z": **Z**3d0X/...

The translation service is not available at the time the blocks are registered so translations will be completely ignored.

This is easily demonstrated in this repo: https://github.com/martin-ro/fabricator-translation

I've cloned `z3d0x/filament-fabricator` into the packages directory and changed the name to "**aaa**z3d0x/filament-fabricator". You'll see that a CuratorPicker for example is not translated anymore.

This really is an edge case and only affects packages that are alphabetically after "z3d0x" loaded (that's how I discovered it). 

However, I think it's still a bug worth fixing. If you ever move the package into another namespace it will break for everyone depending on naming.

**This PR implements https://laravel.com/docs/11.x/providers#deferred-providers:**

> ... you may choose to defer its registration until one of the registered bindings is actually needed Deferring the loading of such a provider will improve the performance of your application, since it is not loaded from the filesystem on every request.
> ... Then, only when you attempt to resolve one of these services does Laravel load the service provider.

Personally, I only use the blocks and nothing else. I don't know how that would interfere with the rest of the package. 
What do you think @Z3d0X ?

Best,

Martin