### PR TITLE
Add constants for layout render hooks

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -126,6 +126,8 @@ Apart from these this plugin also adds the following [Filament's Render Hooks](h
 
 > Pro Tip 💡:  Using a base layout is completely optional, if you don't need it you may just remove it from the generated layout blade file. If you prefer, You may also use your own base layout.
 
+> Pro Tip 💡:  You might prefer using the corresponding constants defined in `\Z3d0X\FilamentFabricator\View\LayoutRenderHook` instead of hard-coded strings.
+
 ## Page Blocks
 
 ### Creating a Page Block

--- a/resources/views/components/layouts/base.blade.php
+++ b/resources/views/components/layouts/base.blade.php
@@ -1,67 +1,71 @@
 @props([
     'title' => null,
-    'dir' => 'ltr'
+    'dir' => 'ltr',
 ])
 
+@use(Z3d0X\FilamentFabricator\View\LayoutRenderHook)
+
 <!DOCTYPE html>
-<html
-    lang="{{ str_replace('_', '-', app()->getLocale()) }}"
-    dir="{{ $dir }}"
-    class="filament-fabricator"
->
-    <head>
-        {{ \Filament\Support\Facades\FilamentView::renderHook('filament-fabricator::head.start') }}
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" dir="{{ $dir }}" class="filament-fabricator">
 
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="csrf-token" content="{{ csrf_token() }}">
+<head>
+    {{ \Filament\Support\Facades\FilamentView::renderHook(LayoutRenderHook::HEAD_START) }}
 
-        @foreach (\Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getMeta() as $tag)
-            {{ $tag }}
-        @endforeach
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
 
-        @if ($favicon = \Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getFavicon())
-            <link rel="icon" href="{{ $favicon }}">
+    @foreach (\Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getMeta() as $tag)
+        {{ $tag }}
+    @endforeach
+
+    @if ($favicon = \Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getFavicon())
+        <link rel="icon" href="{{ $favicon }}">
+    @endif
+
+    <title>{{ $title ? "{$title} - " : null }} {{ config('app.name') }}</title>
+
+
+    <style>
+        [x-cloak=""],
+        [x-cloak="x-cloak"],
+        [x-cloak="1"] {
+            display: none !important;
+        }
+    </style>
+
+
+    @foreach (\Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getStyles() as $name => $path)
+        @if (\Illuminate\Support\Str::of($path)->startsWith('<'))
+            {!! $path !!}
+        @else
+            <link rel="stylesheet" href="{{ $path }}" />
         @endif
+    @endforeach
 
-        <title>{{ $title ? "{$title} - " : null }} {{ config('app.name') }}</title>
+    {{ \Filament\Support\Facades\FilamentView::renderHook(LayoutRenderHook::HEAD_END) }}
+</head>
 
+<body class="filament-fabricator-body">
+    {{ \Filament\Support\Facades\FilamentView::renderHook(LayoutRenderHook::BODY_START) }}
 
-        <style>
-            [x-cloak=""], [x-cloak="x-cloak"], [x-cloak="1"] { display: none !important; }
-        </style>
+    {{ $slot }}
 
+    {{ \Filament\Support\Facades\FilamentView::renderHook(LayoutRenderHook::SCRIPTS_START) }}
 
-        @foreach (\Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getStyles() as $name => $path)
-            @if (\Illuminate\Support\Str::of($path)->startsWith('<'))
-                {!! $path !!}
-            @else
-                <link rel="stylesheet" href="{{ $path }}" />
-            @endif
-        @endforeach
+    @foreach (\Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getScripts() as $name => $path)
+        @if (\Illuminate\Support\Str::of($path)->startsWith('<'))
+            {!! $path !!}
+        @else
+            <script defer src="{{ $path }}"></script>
+        @endif
+    @endforeach
 
-        {{ \Filament\Support\Facades\FilamentView::renderHook('filament-fabricator::head.end') }}
-    </head>
+    @stack('scripts')
 
-    <body class="filament-fabricator-body">
-        {{ \Filament\Support\Facades\FilamentView::renderHook('filament-fabricator::body.start') }}
+    {{ \Filament\Support\Facades\FilamentView::renderHook(LayoutRenderHook::SCRIPTS_END) }}
 
-        {{ $slot }}
+    {{ \Filament\Support\Facades\FilamentView::renderHook(LayoutRenderHook::BODY_END) }}
+</body>
 
-        {{ \Filament\Support\Facades\FilamentView::renderHook('filament-fabricator::scripts.start') }}
-
-        @foreach (\Z3d0X\FilamentFabricator\Facades\FilamentFabricator::getScripts() as $name => $path)
-            @if (\Illuminate\Support\Str::of($path)->startsWith('<'))
-                {!! $path !!}
-            @else
-                <script defer src="{{ $path }}"></script>
-            @endif
-        @endforeach
-
-        @stack('scripts')
-
-        {{ \Filament\Support\Facades\FilamentView::renderHook('filament-fabricator::scripts.end') }}
-
-        {{ \Filament\Support\Facades\FilamentView::renderHook('filament-fabricator::body.end') }}
-    </body>
 </html>

--- a/src/View/LayoutRenderHook.php
+++ b/src/View/LayoutRenderHook.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Z3d0X\FilamentFabricator\View;
+
+class LayoutRenderHook
+{
+    const HEAD_START = 'filament-fabricator::head.start';
+
+    const HEAD_END = 'filament-fabricator::head.end';
+
+    const BODY_START = 'filament-fabricator::body.start';
+
+    const SCRIPTS_START = 'filament-fabricator::scripts.start';
+
+    const SCRIPTS_END = 'filament-fabricator::scripts.end';
+
+    const BODY_END = 'filament-fabricator::body.end';
+}


### PR DESCRIPTION
To avoid hard-coding strings in views, typos, and for better autocompletion and "future-proofing", this PR introduces a new class `Z3d0X\FilamentFabricator\View\LayoutRenderHook` (following Filament's own naming convention for this) akin to Filament's [`Filament\View\PanelsRenderHook`](https://github.com/filamentphp/filament/blob/3.x/packages/panels/src/View/PanelsRenderHook.php).

This means that codebases can migrate views from:
```blade
{{ \Filament\Support\Facades\FilamentView::renderHook('filament-fabricator::head.start') }}
```

To:
```blade
{{ \Filament\Support\Facades\FilamentView::renderHook(\Z3d0X\FilamentFabricator\View\LayoutRenderHook::HEAD_START) }}
```

or even:
```blade
@use(Filament\Support\Facades\FilamentView)
@use(Z3d0X\FilamentFabricator\View\LayoutRenderHook)

{{ FilamentView::renderHook(LayoutRenderHook::HEAD_START) }}
```

This also helps with programmatic rendering of hooks.