### PR TITLE
Update PageRoutesService.php

### DIFF
--- a/src/Services/PageRoutesService.php
+++ b/src/Services/PageRoutesService.php
@@ -313,7 +313,11 @@ class PageRoutesService
         // This is done "atomically" with regards to the cache.
         // Note that concurrent read and writes can result in lost updates.
         // And thus in an invalid state.
-        Cache::forever(static::ID_TO_URI_MAPPING, $idToUriMapping);
+        if (empty($idToUriMapping)) {
+            Cache::forget(static::ID_TO_URI_MAPPING);
+        } else {
+            Cache::forever(static::ID_TO_URI_MAPPING, $idToUriMapping);
+        }
     }
 
     /**
@@ -327,6 +331,10 @@ class PageRoutesService
         // This is done "atomically" with regards to the cache.
         // Note that concurrent read and writes can result in lost updates.
         // And thus in an invalid state.
-        Cache::forever(static::URI_TO_ID_MAPPING, $uriToIdMapping);
+        if (empty($uriToIdMapping)) {
+            Cache::forget(static::URI_TO_ID_MAPPING);
+        } else {
+            Cache::forever(static::URI_TO_ID_MAPPING, $uriToIdMapping);
+        }
     }
 }


### PR DESCRIPTION
For Fix This Error On Run "php artisan optimize:clear" And Run "php artisan optimize" Again

`ErrorException

  Undefined array key 1

  at vendor\z3d0x\filament-fabricator\src\Services\PageRoutesService.php:87
     83▕     public function removeUrlsOf(Page $page): void
     84▕     {
     85▕         // First remove the entries from the (ID -> URI) mapping
     86▕         $idToUrlsMapping = $this->getIdToUrisMapping();
  ➜  87▕         $urls = $idToUrlsMapping[$page->id];
     88▕         $idToUrlsMapping[$page->id] = null;
     89▕         unset($idToUrlsMapping[$page->id]);
     90▕         $this->replaceIdToUriMapping($idToUrlsMapping);
     91▕

  1   vendor\z3d0x\filament-fabricator\src\Services\PageRoutesService.php:87
      Illuminate\Foundation\Bootstrap\HandleExceptions::Illuminate\Foundation\Bootstrap\{closure}("Undefined array key 1", "C:\wamp64\www\*\vendor\z3d0x\filament-fabricator\src\Services\PageRoutesService.php")

  2   vendor\z3d0x\filament-fabricator\src\Commands\ClearRoutesCacheCommand.php:47
      Z3d0X\FilamentFabricator\Services\PageRoutesService::removeUrlsOf(Object(Z3d0X\FilamentFabricator\Models\Page))`

replaceIdToUriMapping & replaceUriToIdMapping Methods Improved To Prevent Storing Cache Keys With Empty Values.