### PR TITLE
Add constants for page resource schema slots

### DIFF
--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -27,6 +27,7 @@ use Z3d0X\FilamentFabricator\Facades\FilamentFabricator;
 use Z3d0X\FilamentFabricator\Forms\Components\PageBuilder;
 use Z3d0X\FilamentFabricator\Models\Contracts\Page as PageContract;
 use Z3d0X\FilamentFabricator\Resources\PageResource\Pages;
+use Z3d0X\FilamentFabricator\View\ResourceSchemaSlot;
 
 class PageResource extends Resource
 {
@@ -46,19 +47,19 @@ class PageResource extends Resource
             ->schema([
                 Group::make()
                     ->schema([
-                        Group::make()->schema(FilamentFabricator::getSchemaSlot('blocks.before')),
+                        Group::make()->schema(FilamentFabricator::getSchemaSlot(ResourceSchemaSlot::BLOCKS_BEFORE)),
 
                         PageBuilder::make('blocks')
                             ->label(__('filament-fabricator::page-resource.labels.blocks')),
 
-                        Group::make()->schema(FilamentFabricator::getSchemaSlot('blocks.after')),
+                        Group::make()->schema(FilamentFabricator::getSchemaSlot(ResourceSchemaSlot::BLOCKS_AFTER)),
                     ])
                     ->columnSpan(2),
 
                 Group::make()
                     ->columnSpan(1)
                     ->schema([
-                        Group::make()->schema(FilamentFabricator::getSchemaSlot('sidebar.before')),
+                        Group::make()->schema(FilamentFabricator::getSchemaSlot(ResourceSchemaSlot::SIDEBAR_BEFORE)),
 
                         Section::make()
                             ->schema([
@@ -126,7 +127,7 @@ class PageResource extends Resource
                                     ),
                             ]),
 
-                        Group::make()->schema(FilamentFabricator::getSchemaSlot('sidebar.after')),
+                        Group::make()->schema(FilamentFabricator::getSchemaSlot(ResourceSchemaSlot::SIDEBAR_AFTER)),
                     ]),
 
             ]);

--- a/src/View/ResourcheSchemaSlot.php
+++ b/src/View/ResourcheSchemaSlot.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Z3d0X\FilamentFabricator\View;
+
+class ResourceSchemaSlot
+{
+    const BLOCKS_BEFORE = 'blocks.before';
+
+    const BLOCKS_AFTER = 'blocks.after';
+
+    const SIDEBAR_BEFORE = 'sidebar.before';
+
+    const SIDEBAR_AFTER = 'sidebar.after';
+}


### PR DESCRIPTION
To avoid hard-coding strings in resource classes, typos, and for better autocompletion and "future-proofing", this PR introduces a new class `Z3d0X\FilamentFabricator\View\ResourceSchemaSlot` similar to #193 for layout render hooks

This means that codebases can migrate resource classes from:

```php
FilamentFabricator::getSchemaSlot('sidebar.after')
```

to

```php
FilamentFabricator::getSchemaSlot(\Z3d0X\FilamentFabricator\View\ResourceSchemaSlot::SIDEBAR_AFTER)
```

or even

```php
use Z3d0X\FilamentFabricator\View\ResourceSchemaSlot;

// [...]

FilamentFabricator::getSchemaSlot(ResourceSchemaSlot::SIDEBAR_AFTER)
```