### PR TITLE
hotfix: Proper clearing of the ID<->URI mappings

### DIFF
--- a/src/Services/PageRoutesService.php
+++ b/src/Services/PageRoutesService.php
@@ -309,11 +309,19 @@ class PageRoutesService
      */
     protected function replaceIdToUriMapping(array $idToUriMapping): void
     {
-        // Replace the ID -> URI[] mapping with the given one.
-        // This is done "atomically" with regards to the cache.
-        // Note that concurrent read and writes can result in lost updates.
-        // And thus in an invalid state.
-        Cache::forever(static::ID_TO_URI_MAPPING, $idToUriMapping);
+        if (empty($idToUriMapping)) {
+            // If the new mapping is empty, that means we've been
+            // cleaning the last entries. Therefore we must
+            // forget the cached data to properly clear it out
+            // and also allow proper cache invalidation
+            Cache::forget(static::ID_TO_URI_MAPPING);
+        } else {
+            // Replace the ID -> URI[] mapping with the given one.
+            // This is done "atomically" with regards to the cache.
+            // Note that concurrent read and writes can result in lost updates.
+            // And thus in an invalid state.
+            Cache::forever(static::ID_TO_URI_MAPPING, $idToUriMapping);
+        }
     }
 
     /**
@@ -323,10 +331,18 @@ class PageRoutesService
      */
     protected function replaceUriToIdMapping(array $uriToIdMapping): void
     {
-        // Replace the URI -> ID mapping with the given one.
-        // This is done "atomically" with regards to the cache.
-        // Note that concurrent read and writes can result in lost updates.
-        // And thus in an invalid state.
-        Cache::forever(static::URI_TO_ID_MAPPING, $uriToIdMapping);
+        if (empty($uriToIdMapping)) {
+            // If the new mapping is empty, that means we've been
+            // cleaning the last entries. Therefore we must
+            // forget the cached data to properly clear it out
+            // and also allow proper cache invalidation
+            Cache::forget(static::URI_TO_ID_MAPPING);
+        } else {
+            // Replace the URI -> ID mapping with the given one.
+            // This is done "atomically" with regards to the cache.
+            // Note that concurrent read and writes can result in lost updates.
+            // And thus in an invalid state.
+            Cache::forever(static::URI_TO_ID_MAPPING, $uriToIdMapping);
+        }
     }
 }


### PR DESCRIPTION
When removing the last entries of any of the two ID<->URI mappings, the cached value used to become an empty array, which in turn broke all read operations from said mapping and thus most of the features related to routing.

The bug could only occur in three situations:
- With the `hook-to-commands` config option set to `true`, when calling any of the `clear` kind of 1st-party artisan commands (note that some commands like `route:cache` also silently call `route:clear` first, so these count as well)
- When installing the package if a script call any of said 1st-party artisan commands (since the option is currently defaulting to `true`)
- When deleting the last existing page

This PR addresses this issue by removing the mapping from the cache instead of caching an empty mapping. This effectively clears out the mapping and properly invalidates caches.

Fixes #198