### PR TITLE
proposal: Replace the default middleware list by the 'web' middleware group

### DIFF
--- a/config/filament-fabricator.php
+++ b/config/filament-fabricator.php
@@ -24,13 +24,7 @@ return [
     ],
 
     'middleware' => [
-        \Illuminate\Cookie\Middleware\EncryptCookies::class,
-        \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
-        \Illuminate\Session\Middleware\StartSession::class,
-        // \Illuminate\Session\Middleware\AuthenticateSession::class,
-        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
-        \Illuminate\Foundation\Http\Middleware\VerifyCsrfToken::class,
-        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        'web',
     ],
 
     'page-model' => \Z3d0X\FilamentFabricator\Models\Page::class,


### PR DESCRIPTION
The `filament-fabricator.middleware` config option's default value was the exhaustive array of middlewares used for the `web` middleware group/alias (with `\Illuminate\Session\Middleware\AuthenticateSession::class` added commented in the middle).

This PR proposes to replace the new default with simply an array containing only the `'web'` middleware group, effectively achievement the same results (for most use cases) without having to maintain two middleware stacks (one in the app's kernel, the other in this package's config).

Users cans still modify the middleware stack to suit their needs should they need to.