### PR TITLE
Null Page Reference in FilamentFabricator Block Preloading

### DIFF
--- a/resources/views/components/page-blocks.blade.php
+++ b/resources/views/components/page-blocks.blade.php
@@ -10,7 +10,7 @@
          */
         $blockClass = FilamentFabricator::getPageBlockFromName($blockType);
 
-        if (!empty($blockClass)) {
+        if (!empty($blockClass) && $page !== null) {
             $blockClass::preloadRelatedData($page, $group);
         }
     }


### PR DESCRIPTION
Added a null check for the `$page` variable in the preloading logic:

```php
// Before
if (!empty($blockClass)) {
    $blockClass::preloadRelatedData($page, $group);
}

// After
if (!empty($blockClass) && $page !== null) {
    $blockClass::preloadRelatedData($page, $group);
}
```

Related issue: [https://github.com/Z3d0X/filament-fabricator/issues/213](url)