### PR TITLE
Fix: resolve PHP 8 deprecation warning in namespace handling

### DIFF
--- a/src/FilamentFabricatorServiceProvider.php
+++ b/src/FilamentFabricatorServiceProvider.php
@@ -142,7 +142,7 @@ class FilamentFabricatorServiceProvider extends PackageServiceProvider
 
                     return (string) $namespace
                         ->append('\\', $file->getRelativePathname())
-                        ->replace('*', $variableNamespace)
+                        ->when($variableNamespace, fn ($namespace) => $namespace->replace('*', $variableNamespace))
                         ->replace(['/', '.php'], ['\\', '']);
                 })
                 ->filter(fn (string $class): bool => is_subclass_of($class, $baseClass) && (! (new ReflectionClass($class))->isAbstract()))


### PR DESCRIPTION
Fixes str_replace() null parameter deprecation by switching to a safer conditional  approach with when().

This prevents the warning log "Passing null to parameter #2  ($replace) of type array|string is deprecated" when $variableNamespace is null when using PHP 8.1+