### PR TITLE
fix: prevent undefined array key error in removeUrlsOf when page ID is missing

### DIFF
--- a/src/Services/PageRoutesService.php
+++ b/src/Services/PageRoutesService.php
@@ -85,6 +85,9 @@ class PageRoutesService
     {
         // First remove the entries from the (ID -> URI) mapping
         $idToUrlsMapping = $this->getIdToUrisMapping();
+        if(!array_key_exists($page->id, $idToUrlsMapping)){
+            return;
+        }
         $urls = $idToUrlsMapping[$page->id];
         $idToUrlsMapping[$page->id] = null;
         unset($idToUrlsMapping[$page->id]);


### PR DESCRIPTION
Added a check to ensure the page ID exists in the ID-to-URI mapping before attempting to access it, preventing potential "undefined array key" errors during URL removal.

I was facing following error. This error seems to be related to the route parsing logic within PageRoutesService. The issue is triggered when accessing or generating certain dynamic pages

![image](https://github.com/user-attachments/assets/6e19b745-3150-4502-a78d-639fac984478)
