### PR TITLE
Fix: bind page route when runnning unit tests

### DIFF
--- a/src/FilamentFabricatorServiceProvider.php
+++ b/src/FilamentFabricatorServiceProvider.php
@@ -77,7 +77,7 @@ class FilamentFabricatorServiceProvider extends PackageServiceProvider
 
     public function bootingPackage(): void
     {
-        if (! $this->app->runningInConsole()) {
+        if (! $this->app->runningInConsole() || $this->app->runningUnitTests()) {
             Route::bind('filamentFabricatorPage', function ($value) {
                 /**
                  * @var PageRoutesService $routesService


### PR DESCRIPTION
This condition will evaluate to true in either of these scenarios:
1. ⁠! $this->app->runningInConsole() - The application is NOT running in the console/CLI (meaning it's handling a web request)
2. $this->app->runningUnitTests() - The application IS running unit tests
