### PR TITLE
change - Rename default layout name from default to main in create_pages_table

### DIFF
--- a/database/migrations/create_pages_table.php.stub
+++ b/database/migrations/create_pages_table.php.stub
@@ -12,7 +12,7 @@ return new class extends Migration
             $table->id();
             $table->string('title')->index();
             $table->string('slug')->unique();
-            $table->string('layout')->default('default')->index();
+            $table->string('layout')->default('main')->index();
             $table->json('blocks');
             $table->foreignId('parent_id')->nullable()->constrained(config('filament-fabricator.table_name', 'pages'))->cascadeOnDelete()->cascadeOnUpdate();
             $table->timestamps();


### PR DESCRIPTION
This will prevent the error "syntax error, unexpected token "default", expecting identifier" from being thrown after running the migrations from scratch and generating a layout with the command "php artisan filament-fabricator:layout Default".