### PR TITLE
Add compatibility with Filament v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 |------|----------|--------|
 | [1.x](https://github.com/z3d0x/filament-fabricator/tree/1.x) | ^2.0 | ^8.0 |
 | [2.x](https://github.com/z3d0x/filament-fabricator/tree/2.x) | ^3.0 | ^8.1 |
+| [^2.6](https://github.com/z3d0x/filament-fabricator/tree/2.x) | ^4.0 | ^8.2 |
 
 ## Installation
 
@@ -51,6 +52,22 @@ Then, publish the registered plugin assets:
 ```
 php artisan filament:assets
 ```
+
+## Migration
+
+### Filament v3 to Filament v4
+
+Since v2.6.0, this package is compatible with both Filament v3 and Filament v4.
+
+To migrate your project that uses this package from Filament v3 to Filament v4, please follow the [Filament upgrade guide](https://filamentphp.com/docs/4.x/upgrade-guide).
+
+Should you encounter an error related to this package during that process, you can also try the following command:
+```bash
+composer require filament/filament:"^4.0" -W --no-update
+composer require z3d0x/filament-fabricator:"^2.6" -W --no-update
+composer update
+```
+
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,15 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "filament/filament": "^3.0",
+        "php": "^8.1 | ^8.2",
+        "filament/filament": "^3.0 | ^4.0",
+        "filament/support": "^3.0 | ^4.0",
         "illuminate/contracts": "^9.0 | ^10.0 | ^11.0 | ^12.0",
-        "pboivin/filament-peek": "^2.0",
+        "pboivin/filament-peek": "^2.0 | ^3.0 | ^3.0.0-beta1 | ^3.x-dev",
         "spatie/laravel-package-tools": "^1.13.5"
     },
     "require-dev": {
-        "larastan/larastan": "^2.9",
+        "larastan/larastan": "^2.9 | ^3.0",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0 | ^8.0",
         "orchestra/testbench": "^8.0 | ^9.0 | ^10.0",


### PR DESCRIPTION
Added compatibility with Filament v4 (no breaking changes in this package's code), which makes the package compatible with both Filament v3 and Filament v4 moving forward.

Package tests are still passing.

A release including this should be at least v2.6.0 to correspond to the documentation as well as make it easier to pin or choose.