### PR TITLE
hotfix: Revert changes made in v2.6.0

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,7 +11,7 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Cache dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
           key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -10,7 +10,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
 
       - name: Update Changelog
         uses: stefanzweifel/changelog-updater-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 All notable changes to `filament-fabricator` will be documented in this file.
 
-## v2.6.0 (Filament v4 Support) - 2025-08-23
-
-### What's Changed
-
-* build(deps): bump actions/cache from 3 to 4 by @dependabot[bot] in https://github.com/Z3d0X/filament-fabricator/pull/232
-* Add compatibility with Filament v4 by @Voltra in https://github.com/Z3d0X/filament-fabricator/pull/235
-* build(deps): bump actions/checkout from 4 to 5 by @dependabot[bot] in https://github.com/Z3d0X/filament-fabricator/pull/234
-
-**Full Changelog**: https://github.com/Z3d0X/filament-fabricator/compare/v2.5.1...v2.6.0
-
 ## v2.5.1 - 2025-08-03
 
 ### What's Changed

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@
 |------|----------|--------|
 | [1.x](https://github.com/z3d0x/filament-fabricator/tree/1.x) | ^2.0 | ^8.0 |
 | [2.x](https://github.com/z3d0x/filament-fabricator/tree/2.x) | ^3.0 | ^8.1 |
-| [^2.6](https://github.com/z3d0x/filament-fabricator/tree/2.x) | ^4.0 | ^8.2 |
 
 ## Installation
 
@@ -52,22 +51,6 @@ Then, publish the registered plugin assets:
 ```
 php artisan filament:assets
 ```
-
-## Migration
-
-### Filament v3 to Filament v4
-
-Since v2.6.0, this package is compatible with both Filament v3 and Filament v4.
-
-To migrate your project that uses this package from Filament v3 to Filament v4, please follow the [Filament upgrade guide](https://filamentphp.com/docs/4.x/upgrade-guide).
-
-Should you encounter an error related to this package during that process, you can also try the following command:
-```bash
-composer require filament/filament:"^4.0" -W --no-update
-composer require z3d0x/filament-fabricator:"^2.6" -W --no-update
-composer update
-```
-
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,14 @@
         }
     ],
     "require": {
-        "php": "^8.1 | ^8.2",
-        "filament/filament": "^3.0 | ^4.0",
-        "filament/support": "^3.0 | ^4.0",
+        "php": "^8.1",
+        "filament/filament": "^3.0",
         "illuminate/contracts": "^9.0 | ^10.0 | ^11.0 | ^12.0",
-        "pboivin/filament-peek": "^2.0 | ^3.0 | ^3.0.0-beta1 | ^3.x-dev",
+        "pboivin/filament-peek": "^2.0",
         "spatie/laravel-package-tools": "^1.13.5"
     },
     "require-dev": {
-        "larastan/larastan": "^2.9 | ^3.0",
+        "larastan/larastan": "^2.9",
         "laravel/pint": "^1.0",
         "nunomaduro/collision": "^7.0 | ^8.0",
         "orchestra/testbench": "^8.0 | ^9.0 | ^10.0",


### PR DESCRIPTION
v2.6.0 introduced what was supposed to be Filament v4 compatibility, but breaking changes (mostly v4 namespaces related) slipped through unit tests.

This PR reverts those changes