### PR TITLE
fix: wrong argument used on getPageUrlFromId breaks page listing on f…

### DIFF
--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -174,7 +174,7 @@ class PageResource extends Resource
                 EditAction::make(),
                 Action::make('visit')
                     ->label(__('filament-fabricator::page-resource.actions.visit'))
-                    ->url(fn (?PageContract $record) => FilamentFabricator::getPageUrlFromId($record->id, true) ?: null)
+                    ->url(fn (?PageContract $record) => FilamentFabricator::getPageUrlFromId($record->id) ?: null)
                     ->icon('heroicon-o-arrow-top-right-on-square')
                     ->openUrlInNewTab()
                     ->color('success')


### PR DESCRIPTION
When trying to access the page listing in a filament v4 panel, an error is thrown:

```
Z3d0X\FilamentFabricator\FilamentFabricatorManager::getPageUrlFromId(): Argument #2 ($args) must be of type array, true given, called in /var/www/html/vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php on line 363
```