### PR TITLE
hotfix: 3.0.2 mishaps

### DIFF
--- a/resources/views/components/forms/components/page-builder.blade.php
+++ b/resources/views/components/forms/components/page-builder.blade.php
@@ -70,7 +70,7 @@
             <ul
                 x-sortable
                 data-sortable-animation-duration="{{ $getReorderAnimationDuration() }}"
-                wire:end.stop="{{ 'mountFormComponentAction(\'' . $statePath . '\', \'reorder\', { items: $event.target.sortable.toArray() })' }}"
+                wire:end.stop="{{ 'mountAction(\'reorder\', { items: $event.target.sortable.toArray() }, { schemaComponent: \'' . $key . '\' })' }}"
                 class="space-y-4"
             >
                 @php

--- a/resources/views/components/forms/components/page-builder.blade.php
+++ b/resources/views/components/forms/components/page-builder.blade.php
@@ -30,15 +30,9 @@
 
     $key = $getKey();
     $statePath = $getStatePath();
-
-    $errors ??= new ViewErrorBag;
-
-    if (!$errors->hasBag('default')) {
-        $errors->put('default', new MessageBag);
-    }
 @endphp
 
-<x-dynamic-component :component="$getFieldWrapperView()" :field="$field" :errors="$errors">
+<x-dynamic-component :component="$getFieldWrapperView()" :field="$field">
     <div
         x-data="{}"
         {{

--- a/resources/views/components/forms/components/page-builder.blade.php
+++ b/resources/views/components/forms/components/page-builder.blade.php
@@ -1,6 +1,8 @@
 @php
     use Filament\Actions\Action;
     use Z3d0X\FilamentFabricator\Enums\BlockPickerStyle;
+    use Illuminate\Support\MessageBag;
+    use Illuminate\Support\ViewErrorBag;
 
     $containers = $getChildComponentContainers();
     $blockPickerBlocks = $getBlockPickerBlocks();
@@ -28,6 +30,12 @@
 
     $key = $getKey();
     $statePath = $getStatePath();
+
+    $errors ??= new ViewErrorBag;
+
+    if (!$errors->hasBag('default')) {
+        $errors->put('default', new MessageBag);
+    }
 @endphp
 
 <x-dynamic-component :component="$getFieldWrapperView()" :field="$field" :errors="$errors">


### PR DESCRIPTION
- Fix `$errors` propagation
- Refactor deprecated use of `mountFormComponentAction`

Addresses #250 #255 

> NB: Despite the filament migration tools existing, it doesn't fully convert a project to v4 due to some of the minor and major changes not having been properly documented