### PR TITLE
Draft Pages (opt-in published_at)

### DIFF
--- a/config/filament-fabricator.php
+++ b/config/filament-fabricator.php
@@ -89,6 +89,12 @@ return [
     'enable-view-page' => false,
 
     /**
+     * Whether you want to enable draft pages
+     * If enabled, pages with a published_at date in the future will not be publicly accessible
+     */
+    'enable-drafts' => false,
+
+    /**
      * Whether to hook into artisan's core commands to clear and refresh page route caches along with the rest.
      * Disable for manual control over cache.
      *

--- a/database/migrations/add_published_at_to_pages_table.php.stub
+++ b/database/migrations/add_published_at_to_pages_table.php.stub
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table(config('filament-fabricator.table_name', 'pages'), function (Blueprint $table) {
+            $table->timestamp('published_at')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table(config('filament-fabricator.table_name', 'pages'), function (Blueprint $table) {
+            $table->dropColumn('published_at');
+        });
+    }
+};

--- a/resources/lang/en/page-resource.php
+++ b/resources/lang/en/page-resource.php
@@ -10,6 +10,7 @@ return [
         'slug' => 'Slug',
         'title' => 'Title',
         'url' => 'URL',
+        'published_at' => 'Published At',
     ],
 
     'errors' => [

--- a/src/FilamentFabricatorServiceProvider.php
+++ b/src/FilamentFabricatorServiceProvider.php
@@ -31,6 +31,7 @@ class FilamentFabricatorServiceProvider extends PackageServiceProvider
             ->hasMigrations(
                 'create_pages_table',
                 'fix_slug_unique_constraint_on_pages_table',
+                'add_published_at_to_pages_table',
             )
             ->hasRoute('web')
             ->hasViews()

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -24,6 +24,12 @@ class PageController
             $filamentFabricatorPage = $routesService->findPageOrFail('/');
         }
 
+        if (config('filament-fabricator.enable-drafts', false) && ! auth()->check()) {
+            if ($filamentFabricatorPage->published_at === null || $filamentFabricatorPage->published_at->isFuture()) {
+                abort(404);
+            }
+        }
+
         /** @var ?class-string<Layout> $layout */
         $layout = FilamentFabricator::getLayoutFromName($filamentFabricatorPage->layout);
 

--- a/src/Models/Page.php
+++ b/src/Models/Page.php
@@ -45,6 +45,7 @@ class Page extends Model implements Contract
         return array_merge(parent::casts(), [
             'blocks' => 'array',
             'parent_id' => 'integer',
+            'published_at' => 'datetime',
         ]);
     }
 }

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -6,6 +6,7 @@ use Closure;
 use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -127,6 +128,10 @@ class PageResource extends Resource
                                             }
                                         }
                                     ),
+
+                                DateTimePicker::make('published_at')
+                                    ->label(__('filament-fabricator::page-resource.labels.published_at'))
+                                    ->visible(config('filament-fabricator.enable-drafts', false)),
                             ]),
 
                         Group::make()->schema(FilamentFabricator::getSchemaSlot(ResourceSchemaSlot::SIDEBAR_AFTER)),


### PR DESCRIPTION
Implements the \published_at\ draft state as discussed in #69.

To use:
1. Publish the migration to add \published_at\ to your pages table.
2. Enable \enable-drafts\ in \ilament-fabricator.php\ config.

When \enable-drafts\ is true, pages with a \published_at\ date in the future or \
ull\ will return 404 for unauthenticated users, but remain previewable for authenticated users.